### PR TITLE
feat(auth): add Outlook OAuth endpoints and org Microsoft users API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,10 @@ GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
 GOOGLE_REDIRECT_URL=https://your-domain.com/api/sessions/oauth/google
 
+MICROSOFT_CLIENT_ID=your_microsoft_application_client_id
+MICROSOFT_CLIENT_SECRET=your_microsoft_client_secret
+MICROSOFT_REDIRECT_URL=https://your-frontend-domain.com/outlook/callback
+
 AI_AGENT_SERVER_URI=http://your-agent-server-url
 AGENT_SERVER_URL=http://your-agent-server-url
 CLIENT_URI=https://your-domain.com/mainapp/profile

--- a/.env.example
+++ b/.env.example
@@ -24,11 +24,19 @@ PYTHON_API_SECRET_KEY=your_python_api_secret_key_here
 
 GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
-GOOGLE_REDIRECT_URL=https://your-domain.com/api/sessions/oauth/google
+# Must match the authorize redirect_uri used for token exchange. For the main Next app profile flow,
+# use the same URL as NEXT_PUBLIC_GOOGLE_OAUTH_REDIRECT_URL (e.g. http://localhost:3000/google/callback).
+# Legacy session flow used: https://your-api-domain.com/api/sessions/oauth/google
+GOOGLE_REDIRECT_URL=https://your-frontend-domain.com/google/callback
 
 MICROSOFT_CLIENT_ID=your_microsoft_application_client_id
 MICROSOFT_CLIENT_SECRET=your_microsoft_client_secret
-MICROSOFT_REDIRECT_URL=https://your-frontend-domain.com/outlook/callback
+# Optional: Azure key vault secret id / tenant for agent orgMicrosoftCredential (defaults: empty secret_id, tenant_id=common)
+# MICROSOFT_SECRET_ID=
+# MICROSOFT_TENANT_ID=common
+# Must match NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL exactly (same string as in the authorize request).
+# Local example: http://localhost:3000/oauthcallback
+MICROSOFT_REDIRECT_URL=https://your-frontend-domain.com/oauthcallback
 
 AI_AGENT_SERVER_URI=http://your-agent-server-url
 AGENT_SERVER_URL=http://your-agent-server-url

--- a/controllers/authCtrl.js
+++ b/controllers/authCtrl.js
@@ -10,8 +10,14 @@ const ResetToken = require("../models/ResetToken");
 const ConfirmToken = require("../models/ConfirmToken");
 const rolePermission = require("../helper/rolePermission");
 const GoogleUser = require("../models/GoogleUser");
+const OutlookUser = require("../models/OutlookUser");
 const axios = require("axios");
-const { getGoogleAuthTokens, getGoogleUser } = require("../service/userService");
+const {
+  getGoogleAuthTokens,
+  getGoogleUser,
+  getMicrosoftAuthTokens,
+  getMicrosoftUser,
+} = require("../service/userService");
 const AgentModel = require("../models/AgentModel");
 const AgentTask = require("../models/AgentTask");
 const INDIVIDUAL_USER_DEFAULT_AGENT = require("../constants/individual-user-default-agent");
@@ -152,6 +158,56 @@ exports.googleOauthCodeExchange = async (req, res) => {
   } catch (err) {}
 };
 
+exports.outlookOauthCodeExchange = async (req, res) => {
+  try {
+    const { code, orgId } = req.body;
+    const emailCredential = await getMicrosoftAuthTokens({ code });
+    if (!emailCredential || !emailCredential.access_token) {
+      return res.status(400).json({
+        success: false,
+        message: "Failed to exchange Microsoft OAuth code",
+      });
+    }
+    const msUser = await getMicrosoftUser({
+      access_token: emailCredential.access_token,
+    });
+    if (!msUser || !msUser.email) {
+      return res.status(400).json({
+        success: false,
+        message: "Failed to retrieve Microsoft user details",
+      });
+    }
+    const existingUser = await User.findOne({
+      email: msUser.email,
+    });
+    let outlookUserPayload = {
+      microsoftId: msUser.id,
+      isOutlookUser: true,
+      user: existingUser ? existingUser.id : null,
+      emailCredential,
+      isActive: true,
+    };
+    if (orgId) {
+      outlookUserPayload.organization = orgId;
+    }
+    await OutlookUser.findOneAndUpdate(
+      { email: msUser.email },
+      outlookUserPayload,
+      { new: true, upsert: true }
+    );
+    res.status(200).json({
+      success: true,
+      message: "Microsoft oauth success",
+    });
+  } catch (err) {
+    console.error("outlookOauthCodeExchange", err);
+    res.status(500).json({
+      success: false,
+      message: "Microsoft oauth failed",
+    });
+  }
+};
+
 exports.disconnectOrgGoogleUser = async (req, res) => {
   try {
     const organization = req.user?.organization;
@@ -169,6 +225,22 @@ exports.disconnectOrgGoogleUser = async (req, res) => {
     await GoogleUser.deleteOne({ organization: organization });
     return res.status(200).json({
       message: "Disconnected google user successfully",
+      success: true,
+    });
+  } catch (err) {
+    res.status(500).json({ message: "Internal server error", err });
+  }
+};
+
+exports.disconnectOrgOutlookUser = async (req, res) => {
+  try {
+    const organization = req.user?.organization;
+    if (!organization) {
+      return res.status(400).json({ message: "Organization is required", success: false });
+    }
+    await OutlookUser.deleteOne({ organization: organization });
+    return res.status(200).json({
+      message: "Disconnected outlook user successfully",
       success: true,
     });
   } catch (err) {
@@ -199,6 +271,30 @@ exports.verifyGoogleLogin = async (req, res) => {
         googleEmail: null,
       });
     }
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+exports.verifyOutlookLogin = async (req, res) => {
+  try {
+    const outlookLoginUser = await OutlookUser.findOne({
+      organization: req.user.organization,
+      isActive: true,
+    }).lean();
+    if (outlookLoginUser) {
+      return res.status(200).json({
+        message: "User successfully connected Outlook",
+        success: true,
+        data: outlookLoginUser,
+      });
+    }
+    return res.status(200).json({
+      message: "Outlook user not found",
+      success: false,
+      outlookEmail: null,
+    });
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: "Internal server error" });

--- a/controllers/authCtrl.js
+++ b/controllers/authCtrl.js
@@ -160,8 +160,15 @@ exports.googleOauthCodeExchange = async (req, res) => {
 
 exports.outlookOauthCodeExchange = async (req, res) => {
   try {
-    const { code, orgId } = req.body;
-    const emailCredential = await getMicrosoftAuthTokens({ code });
+    const { code, orgId, code_verifier } = req.body;
+    console.log(
+      "[outlook-oauth/exchange]",
+      "orgId=",
+      orgId,
+      "code_verifier=",
+      code_verifier ? "present" : "missing"
+    );
+    const emailCredential = await getMicrosoftAuthTokens({ code, code_verifier });
     if (!emailCredential || !emailCredential.access_token) {
       return res.status(400).json({
         success: false,
@@ -190,20 +197,23 @@ exports.outlookOauthCodeExchange = async (req, res) => {
     if (orgId) {
       outlookUserPayload.organization = orgId;
     }
-    await OutlookUser.findOneAndUpdate(
-      { email: msUser.email },
-      outlookUserPayload,
-      { new: true, upsert: true }
-    );
+    await OutlookUser.findOneAndUpdate({ email: msUser.email }, outlookUserPayload, {
+      new: true,
+      upsert: true,
+    });
     res.status(200).json({
       success: true,
       message: "Microsoft oauth success",
     });
   } catch (err) {
-    console.error("outlookOauthCodeExchange", err);
-    res.status(500).json({
+    const ms = err.response?.data;
+    console.error("outlookOauthCodeExchange", ms ? JSON.stringify(ms, null, 2) : err.message);
+    const sc = err.response?.status;
+    const status = typeof sc === "number" && sc >= 400 && sc < 600 ? sc : 500;
+    return res.status(status).json({
       success: false,
-      message: "Microsoft oauth failed",
+      message: ms?.error_description || ms?.error || err.message || "Microsoft oauth failed",
+      error: ms?.error,
     });
   }
 };

--- a/controllers/orgCtrl.js
+++ b/controllers/orgCtrl.js
@@ -1,6 +1,7 @@
 const AGENT_SETUP_DATA = require("../constants/agent-setup-sample-data");
 const Customer = require("../models/Customer");
 const GoogleUser = require("../models/GoogleUser");
+const OutlookUser = require("../models/OutlookUser");
 const Organization = require("../models/Organization");
 const TaskAgentModel = require("../models/TaskAgentModel");
 const User = require("../models/User");
@@ -597,7 +598,53 @@ exports.getConnectedGmailsWithOrg = async (req, res) => {
         data: responsePayload,
       });
     } else {
-      res.status(500).json({ message: "Internal server error", err });
+      res.status(500).json({ message: "Internal server error" });
+    }
+  } catch (err) {
+    res.status(500).json({ message: "Internal server error", err });
+  }
+};
+
+/**
+ * Same JWT/org-token contract as getConnectedGmailsWithOrg, for the AI agent and Microsoft Graph.
+ * Query: token (JWT), email (optional), from_email (mailbox to use).
+ */
+exports.getConnectedOutlooksWithOrg = async (req, res) => {
+  try {
+    const isVerifiedFromExternalCall = req?.externalApiCall && req.organization;
+    const from_email = req.query.from_email;
+    let connectedOutlookQuery = {
+      organization: req.organization._id,
+    };
+    if (isVerifiedFromExternalCall) {
+      if (from_email) {
+        connectedOutlookQuery.email = from_email;
+      }
+      const user_email = req.user.email;
+
+      let connectedOutlookUsers = await OutlookUser.find(connectedOutlookQuery).lean();
+      connectedOutlookUsers = connectedOutlookUsers.map((u) => ({
+        ...u,
+        granted_scope: u.emailCredential?.scope || "",
+      }));
+
+      const orgMicrosoftCredential = {
+        client_id: process.env.MICROSOFT_CLIENT_ID || "",
+        client_secret: process.env.MICROSOFT_CLIENT_SECRET || "",
+        secret_id: process.env.MICROSOFT_SECRET_ID || "",
+        tenant_id: process.env.MICROSOFT_TENANT_ID || "common",
+      };
+
+      const responsePayload = {
+        user_email,
+        orgMicrosoftCredential,
+        connectedOutlooks: connectedOutlookUsers,
+      };
+      res.status(200).json({
+        data: responsePayload,
+      });
+    } else {
+      res.status(500).json({ message: "Internal server error" });
     }
   } catch (err) {
     res.status(500).json({ message: "Internal server error", err });

--- a/docs/outlook-oauth-flow.md
+++ b/docs/outlook-oauth-flow.md
@@ -13,10 +13,10 @@ sequenceDiagram
 
     User->>Frontend: Clicks Connect to Outlook (profile)
     Frontend->>User: Redirect to Microsoft authorize URL
-    Note over Frontend: redirect_uri = NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL<br/>(e.g. https://app.example.com/outlook/callback)<br/>state = JSON e.g. {"auth_flow":"auth_flow","orgId":"..."}
+    Note over Frontend: redirect_uri = NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL<br/>(must match Azure exactly — e.g. https://app.example.com/oauthcallback,<br/>local Next http://localhost:3000/oauthcallback)<br/>state = JSON e.g. {"auth_flow":"auth_flow","orgId":"..."}
 
     User->>Microsoft: Signs in / consents
-    Microsoft->>Frontend: Redirect GET /outlook/callback?code=...&state=...
+    Microsoft->>Frontend: Redirect to redirect_uri with ?code=...&state=...
 
     Frontend->>Backend: POST APP_URL/auth/outlook-oauth/exchange { code, orgId }
     Backend->>Microsoft: POST token endpoint (code, client_id, client_secret, redirect_uri)
@@ -36,30 +36,54 @@ sequenceDiagram
 - **Verify:** `POST APP_URL/auth/outlook-login-verify` (authenticated) — returns whether an `OutlookUser` exists for the caller’s organization.
 - **Disconnect:** `POST APP_URL/auth/outlook-login/disconnect` (authenticated) — removes the org’s Outlook connection record.
 
+## Organization API for agent tools (Python / CoWorkr AI Agent)
+
+The custom agent fetches Microsoft tokens the same way it does for Gmail: **`GET APP_URL/organization/microsoft-users`** with the **same middleware** as [`google-users`](./google-oauth-flow.md) (organization JWT in query: `token`, plus `email` and optional `from_email`).
+
+| Query param  | Purpose                                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| `token`      | JWT identifying the org user (required; validated by `verifyGoogleAuthUser`).                          |
+| `email`      | Present for parity with the Gmail endpoint; the handler uses `req.user` from the token.                |
+| `from_email` | Optional. When set, only the `OutlookUser` row matching this mailbox for the organization is returned. |
+
+**Response `data`:**
+
+- `user_email` — email of the authenticated user.
+- `orgMicrosoftCredential` — `{ client_id, client_secret, secret_id, tenant_id }` from env (`MICROSOFT_*`), used with stored refresh tokens for MSAL/Graph.
+- `connectedOutlooks` — list of Outlook connections for the org (each includes `email`, `emailCredential`, `granted_scope`, etc.).
+
+The Python agent mirrors the Gmail tools pattern (`gmail_outreach`): read, draft, and send via Microsoft Graph using these credentials.
+
 ## Environment variables
 
 ### Backend
 
-| Variable | Purpose |
-| -------- | ------- |
-| `MICROSOFT_CLIENT_ID` | App registration (client) ID in Azure Entra ID. |
-| `MICROSOFT_CLIENT_SECRET` | Client secret for the confidential client app. |
-| `MICROSOFT_REDIRECT_URL` | Must **exactly** match the redirect URI used in the authorize request (same value as `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` on the frontend). |
+| Variable                  | Purpose                                                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MICROSOFT_CLIENT_ID`     | App registration (client) ID in Azure Entra ID.                                                                                                   |
+| `MICROSOFT_CLIENT_SECRET` | Client secret for the confidential client app.                                                                                                    |
+| `MICROSOFT_REDIRECT_URL`  | Must **exactly** match the redirect URI used in the authorize request (same value as `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` on the frontend). |
 
 ### Frontend
 
-| Variable | Purpose |
-| -------- | ------- |
-| `NEXT_PUBLIC_MICROSOFT_CLIENT_ID` | Same client ID as the backend (public in the browser). |
-| `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` | Full URL to the Next.js route `/outlook/callback` (scheme, host, path; no trailing slash unless your app expects it). |
+| Variable                                   | Purpose                                                                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_MICROSOFT_CLIENT_ID`          | Same client ID as the backend (public in the browser).                                                               |
+| `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` | Full redirect URI registered in Azure (e.g. Next dev `http://localhost:3000/oauthcallback`). Must match **exactly**. |
 
 ## Azure app registration
 
 1. Register an **Web** application in Microsoft Entra ID (Azure AD).
 2. Add a **client secret** (for confidential client).
-3. Under **Authentication**, add a **Redirect URI** of type **Web** with the same value as `MICROSOFT_REDIRECT_URL` / `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` (for example `https://your-domain.com/outlook/callback` and `http://localhost:3000/outlook/callback` for local dev).
+3. Under **Authentication**, add a **Redirect URI** of type **Web** with the same value as `MICROSOFT_REDIRECT_URL` / `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` (for example production `https://your-domain.com/oauthcallback`; local Next `http://localhost:3000/oauthcallback`).
 4. Grant **API permissions** (Microsoft Graph, delegated): at minimum `openid`, `profile`, `email`, `offline_access`, `User.Read`, `Mail.Read`, `Mail.ReadWrite` (aligned with the scopes requested in the frontend authorize URL).
 
 ## Redirect URI mismatch
 
 The string Microsoft redirects to after login must match **both** the authorize request’s `redirect_uri` and the token exchange `redirect_uri` on the backend, and must be listed in the Azure app registration.
+
+## PKCE (Proof Key for Code Exchange)
+
+The main Next.js app sends **`code_challenge`** / **`code_challenge_method=S256`** on the authorize request and stores a **`code_verifier`** in `sessionStorage`. The `/oauthcallback` page posts **`code_verifier`** to `POST .../auth/outlook-oauth/exchange` with the **`code`**. The backend includes **`code_verifier`** in the token request. This satisfies Microsoft’s requirement for browser-based (“cross-origin”) authorization code redemption when using a public authorize URL from the SPA.
+
+Server logs: `[Microsoft token]` and `outlookOauthCodeExchange` print the Microsoft error JSON on failure. Browser DevTools: `[Outlook OAuth]` logs each step.

--- a/docs/outlook-oauth-flow.md
+++ b/docs/outlook-oauth-flow.md
@@ -1,0 +1,65 @@
+# Microsoft Outlook OAuth (main app)
+
+This documents the **frontend callback + backend code exchange** flow used by the Next.js app for connecting an organization’s mailbox via Microsoft identity (Outlook / Microsoft 365 Graph), parallel to the Gmail flow described in [google-oauth-flow.md](./google-oauth-flow.md).
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Frontend
+    participant Microsoft
+    participant Backend
+
+    User->>Frontend: Clicks Connect to Outlook (profile)
+    Frontend->>User: Redirect to Microsoft authorize URL
+    Note over Frontend: redirect_uri = NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL<br/>(e.g. https://app.example.com/outlook/callback)<br/>state = JSON e.g. {"auth_flow":"auth_flow","orgId":"..."}
+
+    User->>Microsoft: Signs in / consents
+    Microsoft->>Frontend: Redirect GET /outlook/callback?code=...&state=...
+
+    Frontend->>Backend: POST APP_URL/auth/outlook-oauth/exchange { code, orgId }
+    Backend->>Microsoft: POST token endpoint (code, client_id, client_secret, redirect_uri)
+    Microsoft->>Backend: access_token, refresh_token, ...
+
+    Backend->>Microsoft: GET https://graph.microsoft.com/v1.0/me (Bearer access_token)
+    Microsoft->>Backend: id, mail / userPrincipalName
+
+    Backend->>Backend: Upsert OutlookUser (email, microsoftId, emailCredential, orgId)
+    Backend->>Frontend: 200 { success, message }
+
+    Frontend->>User: Redirect to /mainapp/profile
+```
+
+## Verify and disconnect
+
+- **Verify:** `POST APP_URL/auth/outlook-login-verify` (authenticated) — returns whether an `OutlookUser` exists for the caller’s organization.
+- **Disconnect:** `POST APP_URL/auth/outlook-login/disconnect` (authenticated) — removes the org’s Outlook connection record.
+
+## Environment variables
+
+### Backend
+
+| Variable | Purpose |
+| -------- | ------- |
+| `MICROSOFT_CLIENT_ID` | App registration (client) ID in Azure Entra ID. |
+| `MICROSOFT_CLIENT_SECRET` | Client secret for the confidential client app. |
+| `MICROSOFT_REDIRECT_URL` | Must **exactly** match the redirect URI used in the authorize request (same value as `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` on the frontend). |
+
+### Frontend
+
+| Variable | Purpose |
+| -------- | ------- |
+| `NEXT_PUBLIC_MICROSOFT_CLIENT_ID` | Same client ID as the backend (public in the browser). |
+| `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` | Full URL to the Next.js route `/outlook/callback` (scheme, host, path; no trailing slash unless your app expects it). |
+
+## Azure app registration
+
+1. Register an **Web** application in Microsoft Entra ID (Azure AD).
+2. Add a **client secret** (for confidential client).
+3. Under **Authentication**, add a **Redirect URI** of type **Web** with the same value as `MICROSOFT_REDIRECT_URL` / `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` (for example `https://your-domain.com/outlook/callback` and `http://localhost:3000/outlook/callback` for local dev).
+4. Grant **API permissions** (Microsoft Graph, delegated): at minimum `openid`, `profile`, `email`, `offline_access`, `User.Read`, `Mail.Read`, `Mail.ReadWrite` (aligned with the scopes requested in the frontend authorize URL).
+
+## Redirect URI mismatch
+
+The string Microsoft redirects to after login must match **both** the authorize request’s `redirect_uri` and the token exchange `redirect_uri` on the backend, and must be listed in the Azure app registration.

--- a/models/OutlookUser.js
+++ b/models/OutlookUser.js
@@ -1,0 +1,26 @@
+const mongoose = require("mongoose");
+
+const outlookUserSchema = new mongoose.Schema(
+  {
+    email: { type: String, default: null, unique: true },
+    isOutlookUser: { type: Boolean, default: false },
+    microsoftId: { type: String, default: null },
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    organization: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Organization",
+      default: null,
+    },
+    emailCredential: { type: Object, default: {} },
+    isActive: { type: Boolean, default: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+module.exports = mongoose.model("OutlookUser", outlookUserSchema);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -17,6 +17,13 @@ module.exports = (app) => {
     ctl.disconnectOrgGoogleUser
   );
   app.post(`${process.env.APP_URL}/auth/google-oauth/exchange`, ctl.googleOauthCodeExchange);
+  app.post(`${process.env.APP_URL}/auth/outlook-login-verify`, authUser, ctl.verifyOutlookLogin);
+  app.post(
+    `${process.env.APP_URL}/auth/outlook-login/disconnect`,
+    authUser,
+    ctl.disconnectOrgOutlookUser
+  );
+  app.post(`${process.env.APP_URL}/auth/outlook-oauth/exchange`, ctl.outlookOauthCodeExchange);
 
   // app.post(`${process.env.APP_URL}/auth/tokenRefresh`, ctl.tokenRefresh);
 };

--- a/routes/organization.js
+++ b/routes/organization.js
@@ -1,72 +1,57 @@
-const ctl = require('../controllers/orgCtrl');
-const verifyGoogleAuthUser = require('../middleware/google-auth-verify');
-const permitUser = require('../middleware/permitUser');
-const authUser = require('../middleware/authUser')['authenticate'];
-const checkPermissions = require('../middleware/rolePermit');
-const checkSessionApiKey = require('../middleware/sessionapi');
-const verifySameOrganization = require('../middleware/verifySameOrganization');
-const permissonCheck = checkPermissions('organization');
-const multer = require('multer');
-const path = require('path');
+const ctl = require("../controllers/orgCtrl");
+const verifyGoogleAuthUser = require("../middleware/google-auth-verify");
+const permitUser = require("../middleware/permitUser");
+const authUser = require("../middleware/authUser")["authenticate"];
+const checkPermissions = require("../middleware/rolePermit");
+const checkSessionApiKey = require("../middleware/sessionapi");
+const verifySameOrganization = require("../middleware/verifySameOrganization");
+const permissonCheck = checkPermissions("organization");
+const multer = require("multer");
+const path = require("path");
 const upload = multer({
-  dest: path.join(__dirname, '../uploads/'),
+  dest: path.join(__dirname, "../uploads/"),
   limits: {
     fileSize: 40 * 1024 * 1024, // 40 MB in bytes
   },
 }); // ensure folder exists
-const uploadMiddleware = upload.array('files');
+const uploadMiddleware = upload.array("files");
 
 module.exports = (app) => {
-  app.delete(
-    `${process.env.APP_URL}/organization/source`,
-    authUser,
-    ctl.deleteSourceFile
-  ),
-    app.get(
-      `${process.env.APP_URL}/organization/agent/:id/start`,
-      authUser,
-      ctl.triggerAgent
-    ),
+  (app.delete(`${process.env.APP_URL}/organization/source`, authUser, ctl.deleteSourceFile),
+    app.get(`${process.env.APP_URL}/organization/agent/:id/start`, authUser, ctl.triggerAgent),
     app.post(
       `${process.env.APP_URL}/organization/source/upload-pdf`,
       authUser,
       (req, res, next) => {
         uploadMiddleware(req, res, (err) => {
           if (err) {
-            console.error('Rag file upload error', err.code || err.message, err);
+            console.error("Rag file upload error", err.code || err.message, err);
           }
           if (err instanceof multer.MulterError) {
-            if (err.code === 'LIMIT_FILE_SIZE') {
-              return res
-                .status(400)
-                .json({ error: 'File too large. Max size is 40mMB.' });
+            if (err.code === "LIMIT_FILE_SIZE") {
+              return res.status(400).json({ error: "File too large. Max size is 40mMB." });
             }
-            if (err.code === 'LIMIT_UNEXPECTED_FILE') {
+            if (err.code === "LIMIT_UNEXPECTED_FILE") {
               return res.status(400).json({
                 error: 'Unexpected form field. Files must be sent under the field name "files".',
               });
             }
             return res.status(400).json({ error: err.message });
           } else if (err) {
-            return res.status(500).json({ error: 'File upload failed.' });
+            return res.status(500).json({ error: "File upload failed." });
           }
           next(); // proceed to controller if no errors
         });
       },
       ctl.uploadOrganizationSourceUpload
-    );
+    ));
   app.get(
     `${process.env.APP_URL}/organization/source/file/list`,
     authUser,
     ctl.fetchSourceFileList
   );
   app.get(`${process.env.APP_URL}/customers/`, ctl.getCustomerDetail);
-  app.get(
-    `${process.env.APP_URL}/organization/`,
-    authUser,
-    permissonCheck,
-    ctl.getOrg
-  );
+  app.get(`${process.env.APP_URL}/organization/`, authUser, permissonCheck, ctl.getOrg);
 
   app.get(
     `${process.env.APP_URL}/organization/google-users`,
@@ -75,16 +60,14 @@ module.exports = (app) => {
     ctl.getConnectedGmailsWithOrg
   );
 
-  app.post(
-    `${process.env.APP_URL}/organization/prompts`,
-    authUser,
-    ctl.createOrganizationPrompt
-  );
   app.get(
-    `${process.env.APP_URL}/organization/prompts`,
-    authUser,
-    ctl.getOrganizationPrompt
+    `${process.env.APP_URL}/organization/microsoft-users`,
+    verifyGoogleAuthUser,
+    ctl.getConnectedOutlooksWithOrg
   );
+
+  app.post(`${process.env.APP_URL}/organization/prompts`, authUser, ctl.createOrganizationPrompt);
+  app.get(`${process.env.APP_URL}/organization/prompts`, authUser, ctl.getOrganizationPrompt);
   app.post(
     `${process.env.APP_URL}/organization/prompts/category`,
     authUser,
@@ -97,11 +80,7 @@ module.exports = (app) => {
     ctl.callTaskAgentPythonApi
   );
 
-  app.post(
-    `${process.env.APP_URL}/organization/agent`,
-    authUser,
-    ctl.createOrgAgentInstructions
-  );
+  app.post(`${process.env.APP_URL}/organization/agent`, authUser, ctl.createOrgAgentInstructions);
 
   app.post(
     `${process.env.APP_URL}/organization/agent/:agentId/task/:taskId/status`,
@@ -115,11 +94,7 @@ module.exports = (app) => {
     ctl.getAgentTaskStatus
   );
 
-  app.put(
-    `${process.env.APP_URL}/organization/agent`,
-    authUser,
-    ctl.updateOrgAgentInstructions
-  );
+  app.put(`${process.env.APP_URL}/organization/agent`, authUser, ctl.updateOrgAgentInstructions);
   app.get(
     `${process.env.APP_URL}/organization/agent/instruction`,
     authUser,
@@ -173,12 +148,7 @@ module.exports = (app) => {
     ctl.updateOrgTaskAgents
   );
 
-  app.put(
-    `${process.env.APP_URL}/organization`,
-    authUser,
-    permissonCheck,
-    ctl.editOrg
-  );
+  app.put(`${process.env.APP_URL}/organization`, authUser, permissonCheck, ctl.editOrg);
 
   app.get(
     `${process.env.APP_URL}/organization/:orgId/detail`,
@@ -193,41 +163,18 @@ module.exports = (app) => {
     ctl.upsertOrganizationDetail
   );
 
-  app.post(
-    `${process.env.APP_URL}/organization`,
-    authUser,
-    permissonCheck,
-    ctl.create
-  );
+  app.post(`${process.env.APP_URL}/organization`, authUser, permissonCheck, ctl.create);
   app.put(
     `${process.env.APP_URL}/organization/support-workflow`,
     authUser,
     permissonCheck,
     ctl.saveOrgSupportWorkflow
   );
-  app.get(
-    `${process.env.APP_URL}/organization/greeting_botname`,
-    ctl.getGreeting_botName
-  );
-  app.post(
-    `${process.env.APP_URL}/organization/user`,
-    authUser,
-    permitUser,
-    ctl.createUser
-  );
+  app.get(`${process.env.APP_URL}/organization/greeting_botname`, ctl.getGreeting_botName);
+  app.post(`${process.env.APP_URL}/organization/user`, authUser, permitUser, ctl.createUser);
 
-  app.post(
-    `${process.env.APP_URL}/organization/users`,
-    authUser,
-    permitUser,
-    ctl.findUsers
-  );
-  app.put(
-    `${process.env.APP_URL}/organization/user/:user_id`,
-    authUser,
-    permitUser,
-    ctl.editUser
-  );
+  app.post(`${process.env.APP_URL}/organization/users`, authUser, permitUser, ctl.findUsers);
+  app.put(`${process.env.APP_URL}/organization/user/:user_id`, authUser, permitUser, ctl.editUser);
   app.delete(
     `${process.env.APP_URL}/organization/user/:user_id`,
     authUser,

--- a/service/userService.js
+++ b/service/userService.js
@@ -41,4 +41,47 @@ async function getGoogleUser({ id_token, access_token }) {
   }
 }
 
-module.exports = { getGoogleAuthTokens, getGoogleUser };
+async function getMicrosoftAuthTokens({ code }) {
+  const url = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+  const values = {
+    code,
+    client_id: process.env.MICROSOFT_CLIENT_ID,
+    client_secret: process.env.MICROSOFT_CLIENT_SECRET,
+    redirect_uri: process.env.MICROSOFT_REDIRECT_URL,
+    grant_type: "authorization_code",
+  };
+  try {
+    const res = await axios.post(url, qs.stringify(values), {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+    return res.data;
+  } catch (err) {
+    console.error("Failed to fetch Microsoft oauth token", err.response?.data || err.message);
+  }
+}
+
+async function getMicrosoftUser({ access_token }) {
+  try {
+    const res = await axios.get("https://graph.microsoft.com/v1.0/me", {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    });
+    const data = res.data;
+    return {
+      id: data.id,
+      email: data.mail || data.userPrincipalName,
+    };
+  } catch (err) {
+    console.log("Error fetching Microsoft user", err.response?.data || err.message);
+  }
+}
+
+module.exports = {
+  getGoogleAuthTokens,
+  getGoogleUser,
+  getMicrosoftAuthTokens,
+  getMicrosoftUser,
+};

--- a/service/userService.js
+++ b/service/userService.js
@@ -41,7 +41,7 @@ async function getGoogleUser({ id_token, access_token }) {
   }
 }
 
-async function getMicrosoftAuthTokens({ code }) {
+async function getMicrosoftAuthTokens({ code, code_verifier }) {
   const url = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
   const values = {
     code,
@@ -50,6 +50,9 @@ async function getMicrosoftAuthTokens({ code }) {
     redirect_uri: process.env.MICROSOFT_REDIRECT_URL,
     grant_type: "authorization_code",
   };
+  if (code_verifier) {
+    values.code_verifier = code_verifier;
+  }
   try {
     const res = await axios.post(url, qs.stringify(values), {
       headers: {
@@ -58,7 +61,12 @@ async function getMicrosoftAuthTokens({ code }) {
     });
     return res.data;
   } catch (err) {
-    console.error("Failed to fetch Microsoft oauth token", err.response?.data || err.message);
+    const ms = err.response?.data;
+    console.error(
+      "[Microsoft token] Request failed:",
+      ms ? JSON.stringify(ms, null, 2) : err.message
+    );
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- add Microsoft OAuth exchange, verify, and disconnect flows with Outlook user persistence
- add `GET /organization/microsoft-users` endpoint for agent token/credential retrieval (parity with google-users)
- document Outlook OAuth flow and required environment settings

## Test plan
- [ ] call `POST /auth/outlook-oauth/exchange` with valid OAuth code and verify `OutlookUser` upsert
- [ ] call `POST /auth/outlook-login-verify` and `POST /auth/outlook-login/disconnect` for a connected org
- [ ] call `GET /organization/microsoft-users` with org token and optional `from_email`
- [ ] verify backend still starts and existing auth routes remain functional