### PR TITLE
fix(auth): stabilize Microsoft OAuth token retention

### DIFF
--- a/controllers/orgCtrl.js
+++ b/controllers/orgCtrl.js
@@ -689,6 +689,42 @@ exports.getConnectedOutlooksWithOrg = async (req, res) => {
   }
 };
 
+/**
+ * Persist rotated Microsoft tokens from the AI agent. Entra ID returns a new
+ * refresh_token on every redemption; the newest one must replace the stored one
+ * or the saved credential eventually expires (AADSTS700082 invalid_grant).
+ * Same JWT/org-token contract as getConnectedOutlooksWithOrg.
+ * Body: from_email (mailbox), emailCredential (full token response).
+ */
+exports.updateOutlookCredentialWithOrg = async (req, res) => {
+  try {
+    const isVerifiedFromExternalCall = req?.externalApiCall && req.organization;
+    if (!isVerifiedFromExternalCall) {
+      return res.status(500).json({ message: "Internal server error" });
+    }
+    const { from_email, emailCredential } = req.body;
+    if (!from_email || !emailCredential?.refresh_token) {
+      return res.status(400).json({
+        message: "from_email and emailCredential.refresh_token are required",
+      });
+    }
+    const updated = await OutlookUser.findOneAndUpdate(
+      { organization: req.organization._id, email: from_email },
+      { emailCredential },
+      { new: true }
+    );
+    if (!updated) {
+      return res.status(404).json({ message: "Outlook user not found" });
+    }
+    res.status(200).json({
+      success: true,
+      message: "Outlook credential updated",
+    });
+  } catch (err) {
+    res.status(500).json({ message: "Internal server error", err });
+  }
+};
+
 exports.callTaskAgentPythonApi = async (req, res) => {
   try {
     const { task_name, org_id } = req.body;

--- a/docs/outlook-oauth-flow.md
+++ b/docs/outlook-oauth-flow.md
@@ -54,6 +54,18 @@ The custom agent fetches Microsoft tokens the same way it does for Gmail: **`GET
 
 The Python agent mirrors the Gmail tools pattern (`gmail_outreach`): read, draft, and send via Microsoft Graph using these credentials.
 
+### Refresh-token rotation write-back
+
+Unlike Google, **Entra ID rotates refresh tokens**: every `refresh_token` grant returns a *new* refresh token, and the stored one eventually expires (90-day inactivity limit; `AADSTS700082 invalid_grant`). After each successful refresh the agent must persist the new token response:
+
+**`POST APP_URL/organization/microsoft-users/credentials`** — same auth contract as `microsoft-users` (org JWT in query `token`, plus `orgId`), body:
+
+```json
+{ "from_email": "<mailbox>", "emailCredential": { ...full token response... } }
+```
+
+The agent refresh call itself is a plain confidential-client request — `POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` with `client_id`, `client_secret`, `grant_type=refresh_token`, `refresh_token`, `scope` — no `Origin` header.
+
 ## Environment variables
 
 ### Backend
@@ -61,7 +73,7 @@ The Python agent mirrors the Gmail tools pattern (`gmail_outreach`): read, draft
 | Variable                  | Purpose                                                                                                                                           |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MICROSOFT_CLIENT_ID`     | App registration (client) ID in Azure Entra ID.                                                                                                   |
-| `MICROSOFT_CLIENT_SECRET` | Optional fallback for confidential web-client token exchange (used only when PKCE verifier is not present).                                       |
+| `MICROSOFT_CLIENT_SECRET` | **Required.** The redirect URI is registered under the Web (confidential) platform, so every token request — code exchange and refresh — must include it. |
 | `MICROSOFT_REDIRECT_URL`  | Must **exactly** match the redirect URI used in the authorize request (same value as `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` on the frontend). |
 
 ### Frontend
@@ -75,8 +87,8 @@ The Python agent mirrors the Gmail tools pattern (`gmail_outreach`): read, draft
 
 1. Register an **Web** application in Microsoft Entra ID (Azure AD).
 2. Add a **client secret** (for confidential client).
-3. Under **Authentication**, add a **Redirect URI** of type **Web** with the same value as `MICROSOFT_REDIRECT_URL` / `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` (for example production `https://your-domain.com/oauthcallback`; local Next `http://localhost:3000/oauthcallback`).
-4. Grant **API permissions** (Microsoft Graph, delegated): at minimum `openid`, `profile`, `email`, `offline_access`, `User.Read`, `Mail.Read`, `Mail.ReadWrite` (aligned with the scopes requested in the frontend authorize URL).
+3. Under **Authentication**, add a **Redirect URI** under the **Web** platform (NOT "Single-page application") with the same value as `MICROSOFT_REDIRECT_URL` / `NEXT_PUBLIC_MICROSOFT_OAUTH_REDIRECT_URL` (for example production `https://your-domain.com/oauthcallback`; local Next `http://localhost:3000/oauthcallback`). If the URI is currently listed under the SPA platform, **remove it there first** — SPA-platform tokens can only be redeemed via cross-origin browser requests (`AADSTS9002327`) and their refresh tokens hard-expire after 24 hours, which breaks the server-side agent.
+4. Grant **API permissions** (Microsoft Graph, delegated): at minimum `openid`, `profile`, `email`, `offline_access`, `User.Read`, `Mail.Read`, `Mail.ReadWrite`, `Mail.Send` (aligned with the scopes requested in the frontend authorize URL; `Mail.Send` is required for the agent's outreach send step).
 
 ## Redirect URI mismatch
 
@@ -88,12 +100,8 @@ The main Next.js app sends **`code_challenge`** / **`code_challenge_method=S256`
 
 Backend exchange behavior:
 
-- If `code_verifier` is present, backend redeems the code as SPA/public flow:
-  - sends `code_verifier`
-  - sends `Origin` header derived from `MICROSOFT_REDIRECT_URL`
-  - does **not** send `client_secret`
-- If `code_verifier` is absent, backend falls back to confidential web-client exchange with `client_secret`.
-
-This avoids Microsoft error `AADSTS90023` ("Tokens issued for the 'Single-Page Application' client-type should only be redeemed via cross-origin requests").
+- Always sends `client_secret` (Web/confidential platform requires it on every redemption).
+- Sends `code_verifier` alongside it when present (PKCE and client_secret are complementary, not exclusive).
+- Never sends an `Origin` header — that was a workaround for the redirect URI being misregistered under the SPA platform, which issued 24-hour SPA refresh tokens the Python agent could not redeem (`AADSTS9002327`).
 
 Server logs: `[Microsoft token]` and `outlookOauthCodeExchange` print the Microsoft error JSON on failure. Browser DevTools: `[Outlook OAuth]` logs each step.

--- a/routes/organization.js
+++ b/routes/organization.js
@@ -66,6 +66,12 @@ module.exports = (app) => {
     ctl.getConnectedOutlooksWithOrg
   );
 
+  app.post(
+    `${process.env.APP_URL}/organization/microsoft-users/credentials`,
+    verifyGoogleAuthUser,
+    ctl.updateOutlookCredentialWithOrg
+  );
+
   app.post(`${process.env.APP_URL}/organization/prompts`, authUser, ctl.createOrganizationPrompt);
   app.get(`${process.env.APP_URL}/organization/prompts`, authUser, ctl.getOrganizationPrompt);
   app.post(

--- a/service/userService.js
+++ b/service/userService.js
@@ -46,6 +46,7 @@ async function getMicrosoftAuthTokens({ code, code_verifier }) {
   const values = {
     code,
     client_id: process.env.MICROSOFT_CLIENT_ID,
+    client_secret: process.env.MICROSOFT_CLIENT_SECRET,
     redirect_uri: process.env.MICROSOFT_REDIRECT_URL,
     grant_type: "authorization_code",
   };
@@ -53,26 +54,12 @@ async function getMicrosoftAuthTokens({ code, code_verifier }) {
     "Content-Type": "application/x-www-form-urlencoded",
   };
 
-  // When the code came from the browser authorize request (PKCE), redeem as SPA/public client:
-  // - include code_verifier
-  // - do not send client_secret
-  // - include Origin header so Azure AD accepts cross-origin style redemption
+  // The redirect URI is registered under the Web (confidential) platform in Azure,
+  // so client_secret is required on every redemption — including PKCE ones.
+  // Refresh tokens issued this way are server-redeemable and last 90 days,
+  // unlike SPA-platform tokens which hard-expire after 24 hours (AADSTS9002327).
   if (code_verifier) {
     values.code_verifier = code_verifier;
-    let redirectOrigin = null;
-    if (process.env.MICROSOFT_REDIRECT_URL) {
-      try {
-        redirectOrigin = new URL(process.env.MICROSOFT_REDIRECT_URL).origin;
-      } catch (e) {
-        redirectOrigin = null;
-      }
-    }
-    if (redirectOrigin) {
-      headers.Origin = redirectOrigin;
-    }
-  } else if (process.env.MICROSOFT_CLIENT_SECRET) {
-    // Non-PKCE fallback for confidential web-client flows.
-    values.client_secret = process.env.MICROSOFT_CLIENT_SECRET;
   }
   try {
     const res = await axios.post(url, qs.stringify(values), { headers });


### PR DESCRIPTION
## Problem

Connected Outlook accounts kept losing their credentials. Two root causes:

1. **Wrong token-redemption flow.** The redirect URI is registered under the **Web (confidential)** platform in Azure, but when a PKCE `code_verifier` was present we redeemed the code as an SPA/public client (no `client_secret`, spoofed `Origin` header). SPA-style refresh tokens hard-expire after 24 hours and can't be redeemed server-side by the Python agent (`AADSTS9002327`).
2. **No refresh-token rotation write-back.** Entra ID returns a *new* `refresh_token` on every redemption. Nothing persisted the rotated token, so the stored one eventually became invalid (`AADSTS700082 invalid_grant`).

## Changes

- **`service/userService.js`** — always send `client_secret` on token redemption (required by the Web platform), including alongside `code_verifier` (PKCE and client_secret are complementary). Removed the `Origin`-header SPA workaround and the secret-optional fallback branch.
- **`controllers/orgCtrl.js` + `routes/organization.js`** — new endpoint `POST /organization/microsoft-users/credentials` (same org-token auth contract as `GET /organization/microsoft-users`) so the agent can persist the rotated token response after each refresh.
- **`docs/outlook-oauth-flow.md`** — documented the rotation write-back, marked `MICROSOFT_CLIENT_SECRET` as required, and updated the Azure setup steps: redirect URI must live under the **Web** platform (remove any SPA-platform entry), and `Mail.Send` added to the required Graph permissions.

## Notes for reviewers

- `MICROSOFT_CLIENT_SECRET` is now **required** in every environment — deploys without it will fail token exchange.
- In Azure, if the redirect URI is still listed under the SPA platform it must be removed there, or every redemption fails with `AADSTS9002327`.
- Companion frontend PR adds the `Mail.Send` scope to the authorize URL: sabinss/ai-assistant-frontend#70.

## Testing

- Reconnect an Outlook account end-to-end (authorize → callback → code exchange) and confirm a `refresh_token` is stored.
- Call the new credentials endpoint with a rotated token response and confirm the stored `emailCredential` is replaced.